### PR TITLE
Reduce the chance of race conditions by committing on every iteration

### DIFF
--- a/measurements/filestore.py
+++ b/measurements/filestore.py
@@ -156,6 +156,4 @@ def update_file_metadata(app, target_dir, no_check=False):
         if not add_to_db(app, filepath, index, no_check):
             continue
         idx += 1
-        if idx % 100 == 0:
-            app.db_session.commit()
-    app.db_session.commit()
+        app.db_session.commit()


### PR DESCRIPTION
This should address the issue of duplicate reportfiles inside the ooni-measurements DB.

I believe the correct fix should be that of making the filename column a primary key and hence enforcing uniqueness at the DB layer.
However to do so we will have to migrate the tables and to do that I would have to integrate something like alembic to manage the DB table migration.

So this is just a hotfix for the moment, that should already address the problem (as the race condition is a lot less likely, but still possible).

Edit: I have manually remove the duplicate rows in the production ooni-measurements DB by doing the following:

```sql
DELETE FROM report_files
WHERE id IN (SELECT id
  FROM (SELECT id, ROW_NUMBER()
        OVER (partition BY filename ORDER BY id) AS rnum
              FROM report_files) t
        WHERE t.rnum > 1);
```