### PR TITLE
Fix duplicate DB entries, equal staging/production

### DIFF
--- a/config/development.yml
+++ b/config/development.yml
@@ -1,5 +1,5 @@
 db:
-  image: postgres:9.5
+  image: postgres:9.6
   ports:
     - "5433:5432"
 

--- a/config/staging.yml
+++ b/config/staging.yml
@@ -1,5 +1,5 @@
 db:
-  image: postgres:9.5
+  image: postgres:9.6
   ports:
     - "5433:5432"
 

--- a/config/testing.yml
+++ b/config/testing.yml
@@ -1,5 +1,5 @@
 db:
-  image: postgres:9.5
+  image: postgres:9.6
   ports:
     - "5433:5432"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,15 +9,15 @@ web:
   - rabbitmq
 
 redis:
-  image: redis:latest
+  image: redis:3.2
 
 rabbitmq:
-  image: rabbitmq:latest
+  image: rabbitmq:3.6
 
 worker:
   extends:
     service: app
-  command: celery -A measurements.runcelery.celery worker -l info
+  command: celery -A measurements.runcelery.celery worker --concurrency=1 -l info
   links:
     - redis
     - rabbitmq


### PR DESCRIPTION
* Set redis workers concurrency to 1 to eliminate duplicate DB entries
* Staging should as close as possible to the production build to
  detect issues caused by different software versions and configurations