### PR TITLE
Use Request-Id header, forward it via HTTP and to postgres 

### DIFF
--- a/measurements/api/measurements.py
+++ b/measurements/api/measurements.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import lazyload, exc
 from urllib.parse import urljoin, urlencode
 
 from measurements import __version__
-from measurements.config import REPORT_INDEX_OFFSET
+from measurements.config import REPORT_INDEX_OFFSET, REQID_HDR, request_id
 from measurements.models import Report, Input, Measurement, Autoclaved, Label
 
 MSM_ID_PREFIX = 'temp-id'
@@ -167,7 +167,7 @@ def get_measurement(measurement_id):
     # Largest size of LZ4 frame was ~55Mb compressed and ~56Mb decompressed. :-/
     range_header = "bytes={}-{}".format(msmt.frame_off, msmt.frame_off + msmt.frame_size - 1)
     r = requests.get(urljoin(current_app.config['AUTOCLAVED_BASE_URL'], msmt.a_filename),
-            headers={"Range": range_header})
+            headers={"Range": range_header, REQID_HDR: request_id()})
     r.raise_for_status()
     blob = r.content
     if len(blob) != msmt.frame_size:

--- a/measurements/api/private.py
+++ b/measurements/api/private.py
@@ -23,6 +23,7 @@ from werkzeug.exceptions import BadRequest
 
 from measurements.models import Report, Measurement, Input
 from measurements.models import TEST_NAMES
+from measurements.config import REQID_HDR, request_id
 
 # prefix: /api/_
 api_private_blueprint = Blueprint('api_private', 'measurements')
@@ -267,7 +268,7 @@ def api_private_blockpage_count():
     url = urljoin(current_app.config['CENTRIFUGATION_BASE_URL'],
                   'blockpage-count-%s.json' % probe_cc)
     resp_text = json.dumps({'results': []})
-    resp = requests.get(url)
+    resp = requests.get(url, headers={REQID_HDR: request_id()})
     if resp.status_code != 404:
         resp_text = resp.text
     return current_app.response_class(
@@ -278,7 +279,7 @@ def api_private_blockpage_count():
 @api_private_blueprint.route('/measurement_count_by_country', methods=["GET"])
 def api_private_measurement_count_by_country():
     url = urljoin(current_app.config['CENTRIFUGATION_BASE_URL'], 'count-by-country.json')
-    resp = requests.get(url)
+    resp = requests.get(url, headers={REQID_HDR: request_id()})
     return current_app.response_class(
         resp.text,
         mimetype=current_app.config['JSONIFY_MIMETYPE']
@@ -288,7 +289,7 @@ def api_private_measurement_count_by_country():
 @api_private_blueprint.route('/measurement_count_total', methods=["GET"])
 def api_private_measurement_count_total():
     url = urljoin(current_app.config['CENTRIFUGATION_BASE_URL'], 'count-total.json')
-    resp = requests.get(url)
+    resp = requests.get(url, headers={REQID_HDR: request_id()})
     return current_app.response_class(
         resp.text,
         mimetype=current_app.config['JSONIFY_MIMETYPE']

--- a/measurements/app.py
+++ b/measurements/app.py
@@ -89,6 +89,7 @@ def create_app(*args, **kw):
 
     views.register(app)
 
+    # why is it `teardown_appcontext` and not `teardown_request` ?...
     @app.teardown_appcontext
     def shutdown_session(exception=None):
         app.db_session.remove()

--- a/measurements/config.py
+++ b/measurements/config.py
@@ -14,6 +14,7 @@ CACHE_CONFIG = {'CACHE_TYPE': 'simple'}
 
 APP_ENV = os.environ.get("APP_ENV", "development")
 DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://postgres@localhost:5432/ooni_measurements")
+DATABASE_STATEMENT_TIMEOUT = int(os.environ.get("DATABASE_STATEMENT_TIMEOUT", "0")) # to kill long-running statements ASAP
 
 BASE_URL = os.environ.get("BASE_URL", "https://api.ooni.io/")
 

--- a/measurements/config.py
+++ b/measurements/config.py
@@ -5,6 +5,8 @@ from __future__ import unicode_literals
 
 import os
 
+from flask import request
+
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
 CACHE_DEFAULT_TIMEOUT = None
@@ -29,3 +31,10 @@ S3_ENDPOINT_URL = os.environ.get("S3_ENDPOINT_URL", None)
 
 # As of 2017-07-18 635830 is the latest index in the database
 REPORT_INDEX_OFFSET = int(os.environ.get("REPORT_INDEX_OFFSET", "635830"))
+
+REQID_HDR = "Request-Id"
+
+def request_id():
+    if request:
+        return request.headers.get(REQID_HDR)
+    return None

--- a/measurements/config.py
+++ b/measurements/config.py
@@ -33,7 +33,7 @@ S3_ENDPOINT_URL = os.environ.get("S3_ENDPOINT_URL", None)
 # As of 2017-07-18 635830 is the latest index in the database
 REPORT_INDEX_OFFSET = int(os.environ.get("REPORT_INDEX_OFFSET", "635830"))
 
-REQID_HDR = "Request-Id"
+REQID_HDR = "X-Request-ID"
 
 def request_id():
     if request:

--- a/measurements/database.py
+++ b/measurements/database.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import os
 import time
 
 from sqlalchemy import event
@@ -18,8 +19,19 @@ from measurements.config import request_id
 Base = declarative_base()
 
 def init_db(app):
+    if os.path.exists('/proc/sys/kernel/random/boot_id'): # MacOS...
+        with open('/proc/sys/kernel/random/boot_id') as fd:
+            application_name = 'measurements-{:d}-{}'.format(os.getpid(), fd.read(8))
+    else:
+        application_name = 'measurements-{:d}'.format(os.getpid())
+    connect_args = {
+        # Unfortunately this application_name is not logged during `connection authorized`,
+        # but it is used for `disconnection` event even if the client dies during query!
+        'application_name': application_name,
+        'options': '-c statement_timeout={:d}'.format(app.config['DATABASE_STATEMENT_TIMEOUT']),
+    }
     app.db_engine = create_engine(
-        app.config['DATABASE_URL'], convert_unicode=True
+        app.config['DATABASE_URL'], convert_unicode=True, connect_args=connect_args
     )
     if not database_exists(app.db_engine.url):
         create_database(app.db_engine.url)
@@ -33,7 +45,7 @@ def init_db(app):
     def after_begin(session, transaction, connection):
         reqid = request_id()
         if not reqid:
-            reqid = 'measurements'
+            reqid = application_name
         session.execute('set application_name = :reqid', {'reqid': reqid})
 
 QUERY_TIME_THRESHOLD = 60.0 # Time in seconds after which we will start logging warnings for too long queries

--- a/measurements/models.py
+++ b/measurements/models.py
@@ -36,7 +36,9 @@ TEST_NAMES = {
     'whatsapp': 'WhatsApp',
     'vanilla_tor': 'Vanilla Tor',
     'facebook_messenger': 'Facebook Messenger',
-    'ndt': 'NDT'
+    'ndt': 'NDT',
+    'dash': 'DASH',
+    'telegram': 'Telegram',
 }
 
 # create domain size4 as int4 check (value >= 0);

--- a/measurements/pages/__init__.py
+++ b/measurements/pages/__init__.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 from werkzeug.exceptions import BadRequest, NotFound, HTTPException
 
 from measurements.models import Report, Measurement, Autoclaved
+from measurements.config import REQID_HDR, request_id
 
 # Exporting it
 from .docs import api_docs_blueprint
@@ -239,7 +240,10 @@ def decompress_autoclaved(
         try:
             url = urljoin(current_app.config['AUTOCLAVED_BASE_URL'], autoclaved_filename)
             # byte positions specified are inclusive -- https://tools.ietf.org/html/rfc7233#section-2.1
-            headers = {"Range": "bytes={}-{}".format(frame_off, frame_off + total_frame_size - 1)}
+            headers = {
+                "Range": "bytes={}-{}".format(frame_off, frame_off + total_frame_size - 1),
+                REQID_HDR: request_id(),
+            }
             r = requests.get(url, headers=headers, stream=True)
             r.raise_for_status()
             beginning = True


### PR DESCRIPTION
That's already deployed as `20180126-9610c67d`.

@hellais, can you follow same pattern in new ooni-explorer, and old one, if that's trivial? I tried to do it myself for axios, but got a bit lost while understanding request context accessible from `apiClient.interceptors.request`.