### PR TITLE
Order measurements by test_start_time by default

### DIFF
--- a/measurements/api/measurements.py
+++ b/measurements/api/measurements.py
@@ -191,7 +191,7 @@ def list_measurements(
         since=None,
         until=None,
         since_index=None,
-        order_by=None,
+        order_by='test_start_time',
         order='desc',
         offset=0,
         limit=100,


### PR DESCRIPTION
This aligns the implementation to the spec.

This OONI Explorer PR is also related: https://github.com/TheTorProject/ooni-explorer/pull/122

@darkk if you think this is good, feel free to merge.